### PR TITLE
Update toml version from 0.9.x to 0.10.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = ["machine learning", "software engineering"]
 
 [tool.poetry.dependencies]
 python = "^3.7"  # Compatible python versions must be declared here
-toml = "^0.9"
+toml = "^0.10"
 # Dependencies with extras
 # requests = { version = "^2.13", extras = [ "security" ] }
 # Python specific dependencies with prereleases allowed


### PR DESCRIPTION
Currently `dslinter` depends on `toml`  `0.9.x`.

The latest such `toml` version is quite old, and a lot of other libraries depend on `0.10.x` versions, which have also been available for quite a while.

Bumping `dslinter` up to `0.10.x` should be a simple upgrade, and it would provide better compatibility with other tools often used alongside it (e.g., `dvc`).